### PR TITLE
Add file to restart outlook 

### DIFF
--- a/restart_outlook.py
+++ b/restart_outlook.py
@@ -1,0 +1,11 @@
+import os
+
+ 
+output = os.popen('wmic process get description, processid').read()
+output = [line.split()[:2] for line in output.splitlines() if line and line.strip()]
+output = [line for line in output if 'outlook' in line[0].lower()]
+
+for line in output:
+    os.system('taskkill /PID ' + line[1] + ' /F')
+
+os.system('start outlook')


### PR DESCRIPTION
There is a windows bug making outlook startup impossible, this script kills all running processes and starts outlook again.